### PR TITLE
Make pip install more flexible for conda packaging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,12 +37,15 @@ else:
     aimrocks_extra_link_args += ["-Wl,-rpath,$ORIGIN"]
 
 third_party_install_dir = os.environ.get('AIM_DEP_DIR', '/usr/local')
+
+# By default aimrocks is only linked to rocksdb.
 third_party_deps = ['rocksdb']
 
-third_party_lib_dir = os.path.join(third_party_install_dir, 'lib')
-third_party_libs = glob(os.path.join(third_party_lib_dir, 'librocksdb.*'))
+# `AIMROCKS_LINK_LIBS` can be used to link against additional libraries.
+if os.environ.get("AIMROCKS_LINK_LIBS") is not None:
+    third_party_deps += os.environ.get("AIMROCKS_LINK_LIBS", "").split(",")
 
-third_party_headers = [os.path.join(third_party_install_dir, 'include/rocksdb')]
+third_party_lib_dir = os.path.join(third_party_install_dir, 'lib')
 
 # We define a local include directory to store all the required public headers.
 # The third party headers are copied into this directory to enable binding with
@@ -54,17 +57,25 @@ local_lib_dir = os.path.abspath(
     os.path.join(os.path.dirname(__file__), 'src/aimrocks')
 )
 
-print('third party libs detected:', third_party_libs)
-for source in third_party_libs:
-    print('copying third party lib', source, local_lib_dir)
-    copy_file(source, local_lib_dir)
+if os.environ.get("AIMROCKS_EMBED_ROCKSDB", "1") == "1":
 
-for source in third_party_headers:
-    basename = os.path.basename(source)
-    destination = os.path.join(local_include_dir, basename)
-    copy_tree(source, destination,
-              preserve_symlinks=False, update=True)
+    third_party_libs = glob(os.path.join(third_party_lib_dir, 'librocksdb.*'))
 
+    print('third party libs detected:', third_party_libs)
+    for source in third_party_libs:
+        print('copying third party lib', source, local_lib_dir)
+        copy_file(source, local_lib_dir)
+
+    third_party_headers = [os.path.join(third_party_install_dir, 'include/rocksdb')]
+    for source in third_party_headers:
+        basename = os.path.basename(source)
+        destination = os.path.join(local_include_dir, basename)
+        copy_tree(source, destination,
+                preserve_symlinks=False, update=True)
+
+# `include_dirs` is used to specify the include directories for the extension.
+# It contains the aimrocks local headers and the rocksdb ones.
+include_dirs = [os.path.join(third_party_install_dir, 'include/'), local_include_dir]
 
 exts = [
     Extension(
@@ -73,12 +84,11 @@ exts = [
         extra_compile_args=aimrocks_extra_compile_args,
         extra_link_args=aimrocks_extra_link_args,
         language='c++',
-        include_dirs=[local_include_dir],
+        include_dirs=include_dirs,
         library_dirs=[third_party_lib_dir],
-        libraries=['rocksdb'],
+        libraries=third_party_deps,
     )
 ]
-
 
 setup(
     name="aimrocks",


### PR DESCRIPTION
It allows more flexibility during `pip install`. Example of usage:

```bash
# Locate rocksdb
export AIM_DEP_DIR=$PREFIX

# Do not embed rocksdb in the package
export AIMROCKS_EMBED_ROCKSDB=0

# Link to compression libs as well
export AIMROCKS_LINK_LIBS="bz2,lz4,snappy,z,zstd"

python -m pip install . -vv
```