### PR TITLE
Build Python 3.13 wheels

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,14 +16,14 @@ jobs:
         with:
           python-version: '3.9'
           architecture: x64
-          
+
       - name: Install dev dependencies
         run: |
           python -m pip install twine
-          
+
       - name: Download all the wheels
         uses: actions/download-artifact@v3
-          
+
       - name: Publish wheels
         env:
           PYPI_PASSWORD: ${{ secrets.pypi_password }}
@@ -71,11 +71,11 @@ jobs:
          --mount type=bind,source=$PWD/manylinux_dist,target=/opt/aimrocks/manylinux_dist \
          aimhubio/aimrocks:${{ matrix.manylinux-version }} \
          bash -e /opt/aimrocks/docker/audit-wheels.sh
-         
+
       - uses: actions/upload-artifact@v3
         with:
           path: manylinux_dist/*.whl
-          
+
   linux-dist-x86_64:
     runs-on: ubuntu-latest
     strategy:
@@ -194,7 +194,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: [ '3.6', '3.7', '3.8', '3.9', '3.10' , '3.11', '3.12']
+        python-version: [ '3.6', '3.7', '3.8', '3.9', '3.10' , '3.11', '3.12', '3.13']
         arch: ['arm64', 'x86_64']
         exclude:
           - arch: 'arm64'
@@ -211,7 +211,7 @@ jobs:
       - name: Build and test wheels
         run: |
           arch -${{matrix.arch}} $PYTHON -m build
-          
+
       - uses: actions/upload-artifact@v3
         with:
           path: dist/*.whl

--- a/docker/build-wheels.sh
+++ b/docker/build-wheels.sh
@@ -17,7 +17,7 @@ fi
 cd /opt/aimrocks
 
 echo "build python wheels"
-python_versions=("cp36-cp36m" "cp37-cp37m" "cp38-cp38" "cp39-cp39" "cp310-cp310" "cp311-cp311" "cp312-cp312")
+python_versions=("cp36-cp36m" "cp37-cp37m" "cp38-cp38" "cp39-cp39" "cp310-cp310" "cp311-cp311" "cp312-cp312" "cp313-cp313")
 
 for python_version in "${python_versions[@]}"
 do

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ exts = [
 
 setup(
     name="aimrocks",
-    version='0.5.2',
+    version='0.5.3',
     description='RocksDB wrapper implemented in Cython.',
     setup_requires=['setuptools>=25', 'Cython>=3.0.0a9'],
     packages=find_packages('./src'),
@@ -111,5 +111,6 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ],
 )


### PR DESCRIPTION
Can this be merged and released, please? `aim` is blocking our Python upgrade path, again.