### PR TITLE
Python 3.13 builds

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -22,7 +22,13 @@ jobs:
           python -m pip install twine
           
       - name: Download all the wheels
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+          path: artifact
+      
+      - name: Display structure of downloaded files
+        run: ls -R
           
       - name: Publish wheels
         env:
@@ -42,7 +48,7 @@ jobs:
     name: ${{ matrix.manylinux-version.image }} using Docker on M1 Mac
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
 
       - name: Pull Docker Images
         run: |
@@ -75,9 +81,11 @@ jobs:
          aimhubio/aimrocks:${{ matrix.manylinux-version.image }} \
          bash -e /opt/aimrocks/docker/audit-wheels.sh
          
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: manylinux_dist/*.whl
+          name: artifact-${{ matrix.manylinux-version.image }}
+          if-no-files-found: error
           
   linux-dist-x86_64:
     runs-on: ubuntu-22.04
@@ -97,7 +105,7 @@ jobs:
           sudo systemctl enable --now docker
 
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
 
       - name: Setup python
         uses: actions/setup-python@v2
@@ -144,9 +152,11 @@ jobs:
          aimhubio/aimrocks:${{ matrix.manylinux-version.image }} \
          bash -e /opt/aimrocks/docker/audit-wheels.sh
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: manylinux_dist/*.whl
+          name: artifact-${{ matrix.manylinux-version.image }}
+          if-no-files-found: error
 
   macos-deps:
     runs-on: m1
@@ -166,7 +176,7 @@ jobs:
           rm -rf $AIM_DEP_DIR/*
 
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
 
       - name: Building ZLib
         run: |
@@ -219,6 +229,8 @@ jobs:
         run: |
           arch -${{matrix.arch}} $PYTHON -m build
           
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: dist/*.whl
+          name: artifact-mac-${{ matrix.arch }}-py${{ matrix.python-version }}
+          if-no-files-found: error

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -8,7 +8,7 @@ jobs:
       - linux-dist-aarch64
       - linux-dist-x86_64
       - macos-dist
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Uploading wheels
     steps:
       - name: Setup python
@@ -35,41 +35,44 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        manylinux-version: [ 'manylinux_2_28_aarch64', 'manylinux2014_aarch64', 'manylinux_2_24_aarch64' ]
-    name: ${{ matrix.manylinux-version }} using Docker on M1 Mac
+        manylinux-version:
+          - {image: 'manylinux_2_28_aarch64', tag: '2024-04-23-ef7507e'}
+          - {image: 'manylinux2014_aarch64', tag: '2024-03-25-9206bd9'}
+          - {image: 'manylinux_2_24_aarch64', tag: 'latest'}
+    name: ${{ matrix.manylinux-version.image }} using Docker on M1 Mac
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
 
       - name: Pull Docker Images
         run: |
-         docker pull quay.io/pypa/${{ matrix.manylinux-version }}
+         docker pull quay.io/pypa/${{ matrix.manylinux-version.image }}:${{ matrix.manylinux-version.tag }}
 
-      - name: Building dependencies for ${{ matrix.manylinux-version }}
+      - name: Building dependencies for ${{ matrix.manylinux-version.image }}
         run: |
          docker build \
-         --build-arg FROM=quay.io/pypa/${{ matrix.manylinux-version }} \
+         --build-arg FROM=quay.io/pypa/${{ matrix.manylinux-version.image }}:${{ matrix.manylinux-version.tag }} \
          --target deps .
 
-      - name: Building rocksdb for ${{ matrix.manylinux-version }}
+      - name: Building rocksdb for ${{ matrix.manylinux-version.image }}
         run: |
          docker build \
-         --build-arg FROM=quay.io/pypa/${{ matrix.manylinux-version }} \
+         --build-arg FROM=quay.io/pypa/${{ matrix.manylinux-version.image }}:${{ matrix.manylinux-version.tag }} \
          --target rocksdb .
 
-      - name: Building wheels for ${{ matrix.manylinux-version }}
+      - name: Building wheels for ${{ matrix.manylinux-version.image }}
         run: |
          docker build \
-         --build-arg FROM=quay.io/pypa/${{ matrix.manylinux-version }} \
+         --build-arg FROM=quay.io/pypa/${{ matrix.manylinux-version.image }}:${{ matrix.manylinux-version.tag }} \
          --target wheels . \
-         -t aimhubio/aimrocks:${{ matrix.manylinux-version }}
+         -t aimhubio/aimrocks:${{ matrix.manylinux-version.image }}
 
-      - name: Auditing wheels for ${{ matrix.manylinux-version }}
+      - name: Auditing wheels for ${{ matrix.manylinux-version.image }}
         run: |
          mkdir -p manylinux_dist/ && \
          docker run --rm \
          --mount type=bind,source=$PWD/manylinux_dist,target=/opt/aimrocks/manylinux_dist \
-         aimhubio/aimrocks:${{ matrix.manylinux-version }} \
+         aimhubio/aimrocks:${{ matrix.manylinux-version.image }} \
          bash -e /opt/aimrocks/docker/audit-wheels.sh
          
       - uses: actions/upload-artifact@v3
@@ -77,12 +80,16 @@ jobs:
           path: manylinux_dist/*.whl
           
   linux-dist-x86_64:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
-        manylinux-version: [ 'manylinux1_x86_64', 'manylinux2010_x86_64', 'manylinux2014_x86_64', 'manylinux_2_24_x86_64' ]
-    name: ${{ matrix.manylinux-version }}
+        manylinux-version:
+          - {image: 'manylinux1_x86_64', tag: 'latest'} 
+          - {image: 'manylinux2010_x86_64', tag: 'latest'}
+          - {image: 'manylinux2014_x86_64', tag: '2024-04-23-ef7507e'}
+          - {image: 'manylinux_2_24_x86_64', tag: 'latest'}
+    name: ${{ matrix.manylinux-version.image }}
     steps:
       - name: Install Docker & images
         run: |
@@ -100,41 +107,41 @@ jobs:
 
       - name: Pull Docker Images
         run: |
-         docker pull quay.io/pypa/${{ matrix.manylinux-version }}
+         docker pull quay.io/pypa/${{ matrix.manylinux-version.image }}:${{ matrix.manylinux-version.tag }}
 
       - uses: satackey/action-docker-layer-caching@v0.0.11
         # Ignore the failure of a step and avoid terminating the job.
         continue-on-error: true
         with:
-          key: aimrocks-cython-manylinux-build-${{ matrix.manylinux-version }}-{hash}
+          key: aimrocks-cython-manylinux-build-${{ matrix.manylinux-version.image }}-{hash}
           restore-keys: |
-            aimrocks-cython-manylinux-build-${{ matrix.manylinux-version }}-
+            aimrocks-cython-manylinux-build-${{ matrix.manylinux-version.image }}-
 
-      - name: Building dependencies for ${{ matrix.manylinux-version }}
+      - name: Building dependencies for ${{ matrix.manylinux-version.image }}
         run: |
          docker build \
-         --build-arg FROM=quay.io/pypa/${{ matrix.manylinux-version }} \
+         --build-arg FROM=quay.io/pypa/${{ matrix.manylinux-version.image }}:${{ matrix.manylinux-version.tag }} \
          --target deps .
 
-      - name: Building rocksdb for ${{ matrix.manylinux-version }}
+      - name: Building rocksdb for ${{ matrix.manylinux-version.image }}
         run: |
          docker build \
-         --build-arg FROM=quay.io/pypa/${{ matrix.manylinux-version }} \
+         --build-arg FROM=quay.io/pypa/${{ matrix.manylinux-version.image }}:${{ matrix.manylinux-version.tag }} \
          --target rocksdb .
 
-      - name: Building wheels for ${{ matrix.manylinux-version }}
+      - name: Building wheels for ${{ matrix.manylinux-version.image }}
         run: |
          docker build \
-         --build-arg FROM=quay.io/pypa/${{ matrix.manylinux-version }} \
+         --build-arg FROM=quay.io/pypa/${{ matrix.manylinux-version.image }}:${{ matrix.manylinux-version.tag }} \
          --target wheels . \
-         -t aimhubio/aimrocks:${{ matrix.manylinux-version }}
+         -t aimhubio/aimrocks:${{ matrix.manylinux-version.image }}
 
-      - name: Auditing wheels for ${{ matrix.manylinux-version }}
+      - name: Auditing wheels for ${{ matrix.manylinux-version.image }}
         run: |
          mkdir -p manylinux_dist/ && \
          docker run --rm \
          --mount type=bind,source=$PWD/manylinux_dist,target=/opt/aimrocks/manylinux_dist \
-         aimhubio/aimrocks:${{ matrix.manylinux-version }} \
+         aimhubio/aimrocks:${{ matrix.manylinux-version.image }} \
          bash -e /opt/aimrocks/docker/audit-wheels.sh
 
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -161,7 +161,7 @@ jobs:
   macos-deps:
     runs-on: m1
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         arch: ['arm64', 'x86_64']
     name: Preparing dependencies for ${{ matrix.arch }} Mac build
@@ -209,7 +209,7 @@ jobs:
     runs-on: m1
     needs: macos-deps
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         python-version: [ '3.6', '3.7', '3.8', '3.9', '3.10' , '3.11', '3.12']
         arch: ['arm64', 'x86_64']

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -211,7 +211,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.6', '3.7', '3.8', '3.9', '3.10' , '3.11', '3.12']
+        python-version: [ '3.6', '3.7', '3.8', '3.9', '3.10' , '3.11', '3.12', '3.13']
         arch: ['arm64', 'x86_64']
         exclude:
           - arch: 'arm64'

--- a/docker/build-wheels.sh
+++ b/docker/build-wheels.sh
@@ -17,7 +17,7 @@ fi
 cd /opt/aimrocks
 
 echo "build python wheels"
-python_versions=("cp36-cp36m" "cp37-cp37m" "cp38-cp38" "cp39-cp39" "cp310-cp310" "cp311-cp311" "cp312-cp312")
+python_versions=("cp36-cp36m" "cp37-cp37m" "cp38-cp38" "cp39-cp39" "cp310-cp310" "cp311-cp311" "cp312-cp312" "cp313-cp313")
 
 for python_version in "${python_versions[@]}"
 do

--- a/docker/build-wheels.sh
+++ b/docker/build-wheels.sh
@@ -24,7 +24,9 @@ do
   python_exe=/opt/python/${python_version}/bin/python
   if [ -f "$python_exe" ]
   then
+    echo "##[group]Building ${python_version}\n\n" >&2
     $python_exe -m build
     rm -rf build
+    echo "##[endgroup]"
   fi
 done

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "cython >= 3.0.0a9"]
+requires = ["setuptools", "cython == 3.0.12"]

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -2,4 +2,4 @@ pytest
 wheel
 twine
 flake8
-Cython==3.0.0a9
+Cython==3.0.12

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ setup(
     name="aimrocks",
     version='0.5.2',
     description='RocksDB wrapper implemented in Cython.',
-    setup_requires=['setuptools>=25', 'Cython>=3.0.0a9'],
+    setup_requires=['setuptools>=25', 'Cython==3.0.12'],
     packages=find_packages('./src'),
     package_dir={'': 'src'},
     package_data={'aimrocks': ['src/*']},

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ exts = [
 
 setup(
     name="aimrocks",
-    version='0.5.2',
+    version='0.6.0',
     description='RocksDB wrapper implemented in Cython.',
     setup_requires=['setuptools>=25', 'Cython==3.0.12'],
     packages=find_packages('./src'),

--- a/setup.py
+++ b/setup.py
@@ -111,5 +111,6 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ],
 )


### PR DESCRIPTION
- for some unknown reason Cython project removed one of the versions (yanked! not removed) from PyPI, so we were encountering lots of issues there. Upgrading to 3.0.12. The latest version was incompatible. Maybe needs some time to invest to make it work with the most recent one.
- both GitHub Actions `checkout` and `artifacts` were deprecated. The new format was incompatible, and needed some adjustments
- added more strict versioning, as even building the older stable version from main failed. apparently these versioning differences were not causing the main issue, but it's better to have more reproducible / deterministic behaviour
- adding python 3.13
- reconfiguring python 3.13 on the self-hosted runners
- fail-fast: false will sometimes waste resources, but for now let's keep it for easier debugging
- bumping up the version to 0.6.0 for the release
- the dev version is already available at `pip install aimrocks==0.5.3.dev8`